### PR TITLE
Add a json interface to retrieve the light statuses

### DIFF
--- a/lib/sinatra/stoplight_admin.rb
+++ b/lib/sinatra/stoplight_admin.rb
@@ -2,6 +2,7 @@
 
 require 'haml'
 require 'sinatra/base'
+require 'sinatra/json'
 require 'stoplight'
 
 module Sinatra
@@ -118,6 +119,13 @@ module Sinatra
         stats = stat_params(ls)
 
         haml :index, locals: stats.merge(lights: ls)
+      end
+
+      app.get '/stats' do
+        ls    = lights
+        stats = stat_params(ls)
+
+        json({stats: stats, lights: ls})
       end
 
       app.post '/lock' do

--- a/stoplight-admin.gemspec
+++ b/stoplight-admin.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |gem|
     'haml' => '4.0',
     'redis' => '3.2',
     'sinatra' => '1.4',
+    'sinatra-contrib' => '1.4',
     'stoplight' => '1.0'
   }.each do |name, version|
     gem.add_dependency(name, "~> #{version}")


### PR DESCRIPTION
Small addition, but useful for automatic monitoring of our infrastructure. This allows us to poll using an HTTP api, instead of fiddling with Redis directly.

In this case I opted for the following format since it easier for most clients to consume compared to the nested approach, whereas it gives all information in one call

```json
{
    "stats": {
        "count_red": 0,
        "count_yellow": 0,
        "count_green": 1,
        "percent_red": 0,
        "percent_yellow": 0,
        "percent_green": 100
    },
    "lights": [
        {
            "name": "ElasticSearch",
            "color": "green",
            "failures": [],
            "locked": false
        }
    ]
}
```