### PR TITLE
Depend on stoplight >= 1.4

### DIFF
--- a/stoplight-admin.gemspec
+++ b/stoplight-admin.gemspec
@@ -29,11 +29,12 @@ Gem::Specification.new do |gem|
     'haml' => '4.0',
     'redis' => '3.2',
     'sinatra' => '1.4',
-    'sinatra-contrib' => '1.4',
-    'stoplight' => '1.4'
+    'sinatra-contrib' => '1.4'
   }.each do |name, version|
     gem.add_dependency(name, "~> #{version}")
   end
+
+  gem.add_dependency 'stoplight', '>= 1.4'
 
   {
     'bundler' => '1.10',


### PR DESCRIPTION
Looked at the code. Tested locally with `stoplight v2.1.0`. Doesn't seem to be any reason not to allow it as a dependency.

- Closes orgsync/stoplight#113
- Closes orgsync/stoplight-admin#19