### PR TITLE
Restore Redis 3.2 Support

### DIFF
--- a/stoplight-admin.gemspec
+++ b/stoplight-admin.gemspec
@@ -27,12 +27,12 @@ Gem::Specification.new do |gem|
 
   {
     'haml' => '5.0.4',
-    'redis' => '4.1',
     'sinatra' => '2.0.5'
   }.each do |name, version|
     gem.add_dependency(name, "~> #{version}")
   end
 
+  gem.add_dependency 'redis', '>= 3.2'
   gem.add_dependency 'stoplight', '>= 1.4'
 
   {


### PR DESCRIPTION
As stated in the issue I opened, [Redis Requirement Causing Issue in Rails 5 Upgrade](https://github.com/orgsync/stoplight-admin/issues/23), backing down the Redis requirement (to something similar to what it was before) is needed to safely upgrade our project. 

@camdez @tfausak @orgsync Could you look at this (and the issue in question) and let me know if there is any concern?

![hashtag.gif](https://dl.dropboxusercontent.com/s/we67ufv21aoyqz9/hashtag.gif)