### PR TITLE
Fix sinatra/json error by re-adding sinatra-contrib

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--require spec_helper

--- a/spec/lib/sinatra/stoplight_admin_spec.rb
+++ b/spec/lib/sinatra/stoplight_admin_spec.rb
@@ -3,7 +3,7 @@ require 'sinatra/stoplight_admin'
 
 RSpec.describe Sinatra::StoplightAdmin do
   context 'smoke test' do
-    it' registers itself as a sinatra module' do
+    it 'registers itself as a sinatra module' do
       expect(described_class).to respond_to(:registered)
     end
   end

--- a/spec/lib/sinatra/stoplight_admin_spec.rb
+++ b/spec/lib/sinatra/stoplight_admin_spec.rb
@@ -1,0 +1,10 @@
+require_relative '../../spec_helper'
+require 'sinatra/stoplight_admin'
+
+RSpec.describe Sinatra::StoplightAdmin do
+  context 'smoke test' do
+    it' registers itself as a sinatra module' do
+      expect(described_class).to respond_to(:registered)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,7 @@
+$:.unshift(File.join(File.expand_path('.'), 'lib'))
+
+require 'pry-byebug'
+
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-$:.unshift(File.join(File.expand_path('.'), 'lib'))
+$LOAD_PATH.push(File.join(File.expand_path('.'), 'lib'))
 
 require 'pry-byebug'
 
@@ -15,13 +15,9 @@ RSpec.configure do |config|
 
   begin
     config.filter_run_when_matching :focus
-
     config.disable_monkey_patching!
-
     config.warnings = true
-
     config.default_formatter = 'doc' if config.files_to_run.one?
-
     config.order = :random
 
     Kernel.srand config.seed

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,25 @@
+RSpec.configure do |config|
+  config.expect_with :rspec do |expectations|
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+
+  config.mock_with :rspec do |mocks|
+    mocks.verify_partial_doubles = true
+  end
+
+  config.shared_context_metadata_behavior = :apply_to_host_groups
+
+  begin
+    config.filter_run_when_matching :focus
+
+    config.disable_monkey_patching!
+
+    config.warnings = true
+
+    config.default_formatter = 'doc' if config.files_to_run.one?
+
+    config.order = :random
+
+    Kernel.srand config.seed
+  end
+end

--- a/stoplight-admin.gemspec
+++ b/stoplight-admin.gemspec
@@ -37,6 +37,7 @@ Gem::Specification.new do |gem|
 
   {
     'bundler' => '1.10',
+    'pry-byebug' => '3.7.0',
     'rake' => '11.1',
     'rspec' => '3.8.0'
   }.each do |name, version|

--- a/stoplight-admin.gemspec
+++ b/stoplight-admin.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |gem|
 
   {
     'haml' => '5.0.4',
-    'sinatra' => '2.0.5'
+    'sinatra-contrib' => '2.0.5'
   }.each do |name, version|
     gem.add_dependency(name, "~> #{version}")
   end

--- a/stoplight-admin.gemspec
+++ b/stoplight-admin.gemspec
@@ -37,7 +37,8 @@ Gem::Specification.new do |gem|
 
   {
     'bundler' => '1.10',
-    'rake' => '11.1'
+    'rake' => '11.1',
+    'rspec' => '3.8.0'
   }.each do |name, version|
     gem.add_development_dependency(name, "~> #{version}")
   end


### PR DESCRIPTION
In #22 the `sinatra-contrib` gem was replaced with `sinatra`, but that did not take into account that `sinatra-contrib` is required for the [`require 'sinatra/json'`](https://github.com/orgsync/stoplight-admin/blob/master/lib/sinatra/stoplight_admin.rb#L5) in `lib/sinatra/stoplight_admin.rb`. See the [Sinatra::JSON (part of Sinatra::Contrib)](http://sinatrarb.com/contrib/json.html) for details.

![gus - psych.gif](https://dl.dropboxusercontent.com/s/i6wglrbwcloylvv/gus+-+psych.gif)

@bolshakov Could you take a look at this? Maybe there is a simple way to add specs to help with the altering of the required gems to keep things like this from happening in the future? I'd be glad to assist with that, if needed.

