### PR TITLE
chore: Bump Ruby version

### DIFF
--- a/stoplight-admin.gemspec
+++ b/stoplight-admin.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
     Dir.glob(File.join("lib", "**", "*.rb")) +
     Dir.glob(File.join("lib", "**", "*.erb"))
 
-  gem.required_ruby_version = ">= 3.0.0"
+  gem.required_ruby_version = ">= 3.2"
 
   gem.executables = gem.files.grep(%r{^bin/}) { |f| File.basename(f) }
 


### PR DESCRIPTION
This PR bumps Ruby version to the Stoplight minimum Ruby version.